### PR TITLE
Update qodana-code-quality.yaml

### DIFF
--- a/.github/workflows/qodana-code-quality.yaml
+++ b/.github/workflows/qodana-code-quality.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   qodana:
+    if: github.actor!= 'dependabot-preview[bot]'   # ignore the pull request if it's from Dependabot
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/qodana-code-quality.yaml
+++ b/.github/workflows/qodana-code-quality.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   qodana:
-    if: github.actor!= 'dependabot-preview[bot]'   # ignore the pull request if it's from Dependabot
+    if: github.actor != 'dependabot[bot]'   # ignore the pull request if it's from Dependabot
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
If a PR is created by Dependabot, the Qodana scan should be skipped.