### PR TITLE
fixed most citations

### DIFF
--- a/report/src/sections/01-introduction.tex
+++ b/report/src/sections/01-introduction.tex
@@ -106,7 +106,7 @@ In \autoref{sec:theory} we describe our contribution in detail:
     \item and finally in \autoref{} we show that our analysis will terminate.\todo{Write this section/subsection}
 \end{itemize}
 
-In \autoref{sec:discussion} we discuss the quality of the presented analysis and in \autoref{sec:future-works} we present new avenues for future work.
+In \autoref{sec:discussion} we discuss the quality of the presented analysis and in \autoref{sec:discussion} we also present new avenues for future work.
 Finally the we conclude the paper in \autoref{sec:conclusion}.
 
 

--- a/report/src/sections/06-discussion.tex
+++ b/report/src/sections/06-discussion.tex
@@ -45,7 +45,7 @@ Specifically, in \autoref{tab:table-halder}, we clearly see how their semantics 
 
 
 This means that a situation can happen, where adding more of the same tuples could end up enlarging the analysis indefinitely.
-Specifically, it happens during \textit{infinite} programs with no end state, such as the one shown in \autoref{fig:programgraph}.\todo{Figure does not exist.}
+Specifically, it happens during \textit{infinite} programs with no end state, such as the one shown in \autoref{fig:programgraph}.\todo{Figure in in method - deprecated}
 
 This is exactly what this paper tries to escape.
 As mentioned in \autoref{subsubsec:abstract_domain_of_tables}, using abstract bags of abstract tuples eliminates the possibility of having duplicate tuples.


### PR DESCRIPTION
Currently still two citations are messed up. One in 1.3, where a subsection needs to be written or we should remove the paragraph.
Second is in section 4, where a ref is made to the tikz figure that is moved to deprecated. Either remove citation or include figure again.
